### PR TITLE
Two things

### DIFF
--- a/chrome/js/redirector-ui.js
+++ b/chrome/js/redirector-ui.js
@@ -70,6 +70,7 @@ function trPlural(name, count) {
 function getFile(captionKey, mode) {
 	var picker = new FilePicker(window, tr(captionKey), mode);
 	picker.defaultExtension = ".rjson";
+	picker.defaultString = "Redirector.rjson";
 	var dir = prefs.defaultDir;
 	if (dir) {
 		picker.displayDirectory = new LocalFile(dir);


### PR DESCRIPTION
(1) I noticed that the export wasn't working on my browser (FF10 on OSX), so I fixed it.
(2) Not all OSes automatically append the ext, but the user might not know that, and forget to append the ext (which would make re-importing the exported file hard w/o the .rjson).
