### PR TITLE
Configuration to disable Alt-r hotkey

### DIFF
--- a/chrome/js/browserOverlay.js
+++ b/chrome/js/browserOverlay.js
@@ -18,7 +18,7 @@ var RedirectorOverlay = {
 			this.changedPrefs(this.prefs);
 			this.prefs.addListener(this); 
 			document.addEventListener('keypress', function(event) {
-				if ((event.charCode == 114) && event.altKey) { //alt+r
+				if ((RedirectorOverlay.prefs.enableShortcutKey) && (event.charCode == 114) && event.altKey) { //alt+r
 					RedirectorOverlay.toggleEnabled();
 				}
 			}, true);			

--- a/chrome/redirector.html
+++ b/chrome/redirector.html
@@ -31,6 +31,7 @@
 			<input type="checkbox" id="enable-redirector" data-pref="enabled" /><label>Enabled</label><br />
 			<input type="checkbox" id="show-status-bar-icon" data-pref="showStatusBarIcon"/><label>Statusbar icon</label><br />
 			<input type="checkbox" id="show-context-menu" data-pref="showContextMenu"/><label>Context menu</label><br />
+			<input type="checkbox" id="enable-shortcut-key" data-pref="enableShortcutKey"/><label>Enable/Disable via Alt-r</label><br />
 			<input type="checkbox" id="enable-debug-output" data-pref="debugEnabled"/><label>Debug output</label><br />
 			<div class="button-row">
 				<button id="close">Close</button>

--- a/defaults/preferences/redirector.preferences.js
+++ b/defaults/preferences/redirector.preferences.js
@@ -3,6 +3,7 @@ pref("extensions.redirector.debugEnabled", false);
 pref("extensions.redirector.enabled", true);
 pref("extensions.redirector.showContextMenu", true);
 pref("extensions.redirector.showStatusBarIcon", true);
+pref("extensions.redirector.enableShortcutKey", true);
 pref("extensions.redirector.version", 'undefined');
 pref("extensions.redirector.defaultDir", '');
 pref("extensions.redirector.proxyServerPort", 4815);


### PR DESCRIPTION
The Alt-r hotkey conflicts with reload when the firefox accel key is set to Alt (pref: ui.key.accelKey = 18). This patch simply adds a checkbox to disable the hotkey.
