### PR TITLE
Conditional unescape on Base64 decode

### DIFF
--- a/js/redirect.js
+++ b/js/redirect.js
@@ -246,6 +246,9 @@ Redirect.prototype = {
 				repl = encodeURIComponent(repl);
 			}
 			if (this.processMatches == 'base64decode') {
+				if (repl.indexOf('%') > -1) {
+					repl = unescape(repl);
+				}
 				repl = atob(repl);
 			}
 			resultUrl = resultUrl.replace(new RegExp('\\$' + i, 'gi'), repl);


### PR DESCRIPTION
This patch will fix Base64 decoding if match has % encoded character.
This won't break current decoding system because Base64 can't have % character anyway.

## Example case

```
http://mp3indirdim.com/engine/go.php?url=aHR0cDovL2JpbmcuY29tLw%3D%3D
```

1. This URL will actually redirect user to `http://mp3indirdim.com/` (perfect for our use case)
2. If I add a redirection to `$1` with the settings I provide below, it will **not work** in the current version  
3. Because Redirector will try to decode `aHR0cDovL2JpbmcuY29tLw%3D%3D` instead of `aHR0cDovL2JpbmcuY29tLw==` thus will fail / throw error (`InvalidCharacterError`)

**Settings:**

* Pattern: `http://mp3indirdim.com/engine/go.php?url=*`
* Decoding: Base64

---

Here's some screenshots, to explain the situation:

## Current version

![current2](https://cloud.githubusercontent.com/assets/486818/22677717/89a4b72e-ecfd-11e6-9162-4faa17553455.png)

with error below:

```
06:21:37.992 Error: String contains an invalid character
_includeMatch@moz-extension://642cd274-5404-45c6-959b-4dc568e12c88/js/redirect.js:249:12
getMatch@moz-extension://642cd274-5404-45c6-959b-4dc568e12c88/js/redirect.js:94:16
```

## Patch version

![patch2](https://cloud.githubusercontent.com/assets/486818/22677718/89a75a74-ecfd-11e6-9a0d-fb48e02434a5.png)

---

While testing this, I lost over 50 entries in original Redirector because it removes your data after you remove the add-on 😞😞😞