### PR TITLE
Hide Sync option for firefox in settings page

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -380,7 +380,7 @@ function sendNotifications(redirect, originalUrl, redirectedUrl ){
 	// So let's use useragent. 
 	// Opera UA has both chrome and OPR. So check against that ( Only chrome which supports list) - other browsers to get BASIC type notifications.
 
-	if(navigator.userAgent.toLowerCase().indexOf("chrome") > -1 && navigator.userAgent.toLowerCase().indexOf("OPR")<0){
+	if(navigator.userAgent.toLowerCase().indexOf("chrome") > -1 && navigator.userAgent.toLowerCase().indexOf("opr")<0){
 		var items = [{title:"Original page: ", message: originalUrl},{title:"Redirected to: ",message:redirectedUrl}];
 		var head = "Redirector - Applied rule : " + redirect.description;
 		chrome.notifications.create({

--- a/js/controllers/redirectorpage.js
+++ b/js/controllers/redirectorpage.js
@@ -12,6 +12,10 @@ redirectorApp.controller('RedirectorPageCtrl', ['$scope', '$timeout', function($
 		return new Redirect(r).toObject(); //Cleans out any extra props, and adds default values for missing ones.
 	}
 
+	$s.showSyncOption = false;
+	if(navigator.userAgent.toLowerCase().indexOf("chrome") > -1){
+		$s.showSyncOption = true;
+	}
 	// Saves the entire list of redirects to storage.
 	$s.saveChanges = function() {
 

--- a/redirector.html
+++ b/redirector.html
@@ -193,7 +193,7 @@
 						<a class="btn medium grey padded" ng-click="duplicateRedirect($index)">Duplicate</a>
 					</div>
 				</div>
-				<label id="storage-sync-option"><input type="checkbox" ng-model="isSyncEnabled" ng-click="toggleSyncSetting()" /> Enable Storage Sync</label>
+				<label id="storage-sync-option" ng-if="showSyncOption"><input type="checkbox" ng-model="isSyncEnabled" ng-click="toggleSyncSetting()" /> Enable Storage Sync</label>
 			</div>
 
 			<footer>


### PR DESCRIPTION
This PR hides the sync option in settings page for Firefox which was introduced in PR #120 

https://github.com/einaregilsson/Redirector/issues/127 - Firefox Webextensions API doesn't yet support getBytesInUse and storageArea quota sizes (returns NaN).

Since we shouldn't try moving data across storage area types without measuring the sizes first, we can have it disabled for Firefox until Mozilla provides support.

Also adjusted condition to show "basic" notification in Opera as it doesn't support "List" type that Chrome does. 

Tested these things :
1) Option continues to be shown in Chrome and Opera and rules get copied to Sync area.
2) In Opera and chrome, can copy rules back to Local from Sync. 
3) In Opera and firefox, shows basic notifications. In Chrome, shows List type notifications.
4) In firefox, sync option in hidden in settings page. 