### PR TITLE
Fix Storage Sync Checkbox Initialization on Page Load

### DIFF
--- a/js/redirectorpage.js
+++ b/js/redirectorpage.js
@@ -304,7 +304,7 @@ function pageLoad() {
 
 	chrome.storage.local.get({isSyncEnabled:false}, function(obj){
 		options.isSyncEnabled = obj.isSyncEnabled;
-		el('#storage-sync-option').checked = options.isSyncEnabled;
+		el('#storage-sync-option input').checked = options.isSyncEnabled;
 	});
 
 	if(navigator.userAgent.toLowerCase().indexOf("chrome") > -1){


### PR DESCRIPTION
# Description

This pull request addresses a small issue with the initialization of the storage sync checkbox in the `redirectorpage.js` file. Previously, the checkbox would always appear unchecked upon page load, regardless of the actual sync status. With this fix, the checkbox now properly reflects the sync status on page load.

# Changes

The primary change made in this pull request is to correctly set the `checked` property of the input element for the storage sync checkbox during the initial load. The modified code snippet is as follows:
```js
chrome.storage.local.get({isSyncEnabled:false}, function(obj){
	options.isSyncEnabled = obj.isSyncEnabled;
	el('#storage-sync-option input').checked = options.isSyncEnabled;
});
```

The issue was caused by setting the `checked` property on the `label` element instead of the `input` element. The updated code selects the correct `input` element and sets its `checked` property based on the `isSyncEnabled` value.

# Impact

This change ensures a better user experience, as the storage sync checkbox will now correctly display its status upon loading the page. This helps users understand the current sync setting and reduces confusion when using the extension.

# Testing

To verify the changes, follow these steps:

1. Load the extension with the updated code.
2. Check the storage sync checkbox and refresh the page to ensure the checkbox remains checked.
3. Uncheck the storage sync checkbox and refresh the page to ensure the checkbox remains unchecked.
4. Toggle the storage sync checkbox multiple times and refresh the page to confirm that the checkbox's state is always consistent with the sync status.

Please let me know if you have any questions or need any further clarification. I'm looking forward to hearing your thoughts on this fix, and I hope it improves the extension's user experience!