### PR TITLE
Support media request type

### DIFF
--- a/js/redirect.js
+++ b/js/redirect.js
@@ -20,6 +20,7 @@ Redirect.requestTypes = {
 	script : "Scripts",
 	image : "Images",
 	imageset: "Responsive Images in Firefox",
+	media : "Media (audio and video)",
 	object : "Objects (e.g. Flash content, Java applets)",
 	object_subrequest : "Object subrequests",
 	xmlhttprequest : "XMLHttpRequests (Ajax)",

--- a/redirector.html
+++ b/redirector.html
@@ -111,6 +111,7 @@
 						<label><input type="checkbox" value="script"><span>Scripts</span></label>
 						<label><input type="checkbox" value="image"><span>Images</span></label>
 						<label><input type="checkbox" value="imageset"><span>Responsive Images in Firefox</span></label>
+						<label><input type="checkbox" value="media"><span>Media (audio and video)</span></label>
 						<label><input type="checkbox" value="object"><span>Objects (e.g. Flash videos, Java applets)</span></label>
 						<label><input type="checkbox" value="object_subrequest"><span>Object subrequests</span></label>
 						<label><input type="checkbox" value="xmlhttprequest"><span>XMLHttpRequests (Ajax)</span></label>


### PR DESCRIPTION
This adds support for the [media](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType#media) ResourceType, which redirects `<audio>` and `<video>` tags.

Workaround until this (hopefully) gets merged: export Redirector data, find your redirect, add `"media"` to the `"appliesTo"` array, then import it back. It's clunky and it might remove the media type if you edit things, but it works.