### PR TITLE
Upgrade build.py to Python 3

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os, os.path, re, zipfile, json
 
@@ -13,7 +13,7 @@ def get_files_to_zip():
 
 	zippable_files = []
 	for root, folders, files in os.walk('.'):
-		print root
+		print(root)
 		for f in files:
 			file = os.path.join(root,f)
 			if not any(re.search(p, file) for p in exclude):
@@ -31,19 +31,19 @@ def create_addon(files, browser):
 	else:
 		ext = 'zip'
 
-	output_file = os.path.join(output_folder, 'redirector-%s.%s' % (browser,ext))
+	output_file = os.path.join(output_folder, f'redirector-{browser}.{ext}')
 	zf = zipfile.ZipFile(output_file, 'w', zipfile.ZIP_STORED)
 	cert = 'extension-certificate.pem'
 
-	print ''
-	print '**** Creating addon for %s ****' % browser
+	print('')
+	print(f'**** Creating addon for ${browser} ****')
 	
 	if browser == 'opera' and not os.path.exists(cert):
-		print 'Extension certificate does not exist, cannot create .nex file for Opera'
+		print('Extension certificate does not exist, cannot create .nex file for Opera')
 		return
 
 	for f in files:
-		print 'Adding', f
+		print('Adding', f)
 		if f.endswith('manifest.json'):
 			manifest = json.load(open(f))
 			if browser != 'firefox':
@@ -76,8 +76,8 @@ if __name__ == '__main__':
 
 	files = get_files_to_zip()
 	
-	print '******* REDIRECTOR BUILD SCRIPT *******'
-	print ''
+	print('******* REDIRECTOR BUILD SCRIPT *******')
+	print('')
 
 	create_addon(files, 'chrome')
 	create_addon(files, 'edge')


### PR DESCRIPTION
Adds parentheses around print statements and converts %-strings to f-strings. Most distributions have dropped Python 2 packages, so this should allow people to make use of the build script without having to hunt down Python 2 binaries.