### PR TITLE
checkbox on the redirector page correctly reflects the current sync s…

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,4 +1,3 @@
-
 //This is the background script. It is responsible for actually redirecting requests,
 //as well as monitoring changes in the redirects and the disabled status and reacting to them.
 function log(msg, force) {
@@ -292,6 +291,13 @@ chrome.runtime.onMessage.addListener(
 			});
 		} else if (request.type == 'update-icon') {
 			updateIcon();
+		} else if (request.type == 'get-sync-state') {
+			// Get the current sync state and send it back to the requestor
+			chrome.storage.local.get({isSyncEnabled: false}, function(obj) {
+				sendResponse({
+					isSyncEnabled: obj.isSyncEnabled
+				});
+			});
 		} else if (request.type == 'toggle-sync') {
 			// Notes on Toggle Sync feature here https://github.com/einaregilsson/Redirector/issues/86#issuecomment-389943854
 			// This provides for feature request - issue 86


### PR DESCRIPTION
…etting state

I've made the necessary changes to ensure that the checkbox on the redirector page correctly reflects the current sync setting state. Here's what I've done:

First, I improved the toggleSyncSetting() function in redirectorpage.js to use the actual checkbox state when enabling or disabling sync, rather than always toggling the current setting.

Next, I enhanced the page load process in redirectorpage.js to fetch the sync state directly from the background page using a new message type get-sync-state. This ensures that the checkbox always reflects the true state of the sync setting when the page loads.

Finally, I added a message handler for the new get-sync-state message type in background.js to respond with the current sync state, making the system work properly.

This implementation now:

Correctly sets the checkbox state on page load based on the current sync setting Uses the checkbox state to properly enable or disable sync when the checkbox is clicked Ensures the checkbox state always reflects the actual sync setting, even after errors occur