### PR TITLE
feat: Add export functionality for single redirect

### DIFF
--- a/js/importexport.js
+++ b/js/importexport.js
@@ -93,4 +93,33 @@ function setupImportExportEventListeners() {
 	el("#export-link").addEventListener('mousedown', updateExportLink);
 }
 
+function exportSingleRedirect(index) {
+	var redirect = REDIRECTS[index];
+	if (!redirect) {
+		showMessage('Redirect not found');
+		return;
+	}
+
+	let version = chrome.runtime.getManifest().version;
+
+	var exportObj = { 
+		createdBy : 'Redirector v' + version, 
+		createdAt : new Date(), 
+		redirects : [new Redirect(redirect).toObject()]
+	};
+
+	var json = JSON.stringify(exportObj, null, 4);
+	var filename = (redirect.description || 'My').replace(/[^a-zA-Z0-9]/g, '-').substring(0, 50) + ' redirector.json';
+
+	// Create a temporary link element to trigger download
+	var link = document.createElement('a');
+	link.href = 'data:text/plain;charset=utf-8,' + encodeURIComponent(json);
+	link.download = filename;
+	document.body.appendChild(link);
+	link.click();
+	document.body.removeChild(link);
+
+	showMessage('Successfully exported redirect: ' + (redirect.description || 'Unnamed redirect'), true);
+}
+
 setupImportExportEventListeners();

--- a/redirector.html
+++ b/redirector.html
@@ -192,6 +192,7 @@
 									<button class="btn medium grey move-downbottom-btn arrows" data-action="moveDownBottom" data-disabled="$last">⟱</button>
 								</span>
 								<button class="btn medium grey" data-action="duplicateRedirect">Duplicate</button>
+								<button class="btn medium blue" data-action="exportSingleRedirect">Export</button>
 							</div>
 							<label class="toggle-container">
 								<input class="checkbox" type="checkbox">


### PR DESCRIPTION
Introduced the `exportSingleRedirect` function in `importexport.js` to allow exporting individual redirects as JSON files. Added an `Export` button to each redirect entry in `redirector.html` to trigger this functionality.

Closes #439
