### PR TITLE
Add Base64 encode option to redirector

### DIFF
--- a/help.html
+++ b/help.html
@@ -27,6 +27,7 @@
 							<li><a href="#doubleurldecodematches">Double URL decode matches</a></li>
 							<li><a href="#urlencodematches">URL encode matches</a></li>
 							<li><a href="#base64decodematches">Base64 decode matches</a></li>
+							<li><a href="#base64encodematches">Base64 encode matches</a></li>
 						</ol>
 					</li>
 					<li><a href="#applyto">Apply to</a></li>
@@ -111,6 +112,8 @@
 		        	</li>
 
 		            <li><a name="base64decodematches"></a><strong>Base64 Decode matches:</strong> Similar to URL Decoding, in some cases a parameter in a url might be Base64 encoded. This option will decode that parameter before using it in the target url.
+		            </li>
+		            <li><a name="base64encodematches"></a><strong>Base64 Encode matches:</strong> The opposite of Base64 Decode. This option will encode the matched parameter using Base64 encoding before using it in the target url.
 		            </li>
 		        </ul>
 		    </li>

--- a/js/redirect.js
+++ b/js/redirect.js
@@ -254,6 +254,7 @@ Redirect.prototype = {
 			urlEncode : 'E.g. turn /bar/foo?x=2 into %2Fbar%2Ffoo%3Fx%3D2',
 			urlDecode : 'E.g. turn %2Fbar%2Ffoo%3Fx%3D2 into /bar/foo?x=2',
 			doubleUrlDecode : 'E.g. turn %252Fbar%252Ffoo%253Fx%253D2 into /bar/foo?x=2',
+			base64Encode : 'E.g. turn http://cnn.com into aHR0cDovL2Nubi5jb20=',
 			base64Decode : 'E.g. turn aHR0cDovL2Nubi5jb20= into http://cnn.com'
 		};
 
@@ -281,7 +282,9 @@ Redirect.prototype = {
 				repl = unescape(unescape(repl));
 			} else if (this.processMatches == 'urlEncode') {
 				repl = encodeURIComponent(repl);
-			} else if (this.processMatches == 'base64decode') {
+			} else if (this.processMatches == 'base64Encode') {
+				repl = btoa(repl);
+			} else if (this.processMatches == 'base64Decode') {
 				if (repl.indexOf('%') > -1) {
 					repl = unescape(repl);
 				}

--- a/redirector.html
+++ b/redirector.html
@@ -96,7 +96,8 @@
 							<option value="urlEncode">URL Encode</option>
 							<option value="urlDecode">URL Decode</option>
 							<option value="doubleUrlDecode">Double URL Decode</option>
-							<option value="base64decode">Base64 Decode</option>
+							<option value="base64Encode">Base64 Encode</option>
+							<option value="base64Decode">Base64 Decode</option>
 						</select>
 						<span class="placeholder" data-bind="processMatchesExampleText"></span>
 					</div>


### PR DESCRIPTION
Introduces a Base64 encode option alongside the existing decode option in both the UI and processing logic. Updates example texts and ensures correct handling of Base64 encoding and decoding in redirect.js.

Resolves #183