### PR TITLE
Add 'Delete All Redirects' confirmation dialog

### DIFF
--- a/css/redirector.css
+++ b/css/redirector.css
@@ -364,6 +364,86 @@ a.disabled:hover, button[disabled]:hover {
   vertical-align: top;
 }
 
+#delete-all-form {
+  position: fixed;
+  padding: 20px;
+  width: 500px;
+  background: white;
+  border: solid 2px #d32f2f;
+  border-radius: 8px;
+  z-index: 6000;
+  left: 50%;
+  margin-left: -260px;
+  top: 50%;
+  margin-top: -150px;
+  height: auto;
+  min-height: 200px;
+  display: none;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+#delete-all-form h3 {
+  color: #d32f2f;
+  margin: 0 0 15px 0;
+  font-size: 18px;
+  font-weight: bold;
+  text-align: center;
+}
+
+#delete-all-form p {
+  color: #333;
+  margin: 10px 0;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+#delete-all-form p strong {
+  color: #d32f2f;
+  font-weight: bold;
+}
+
+/* Dark mode styles for delete all form */
+@media (prefers-color-scheme: dark) {
+  #delete-all-form {
+    background: #2d2d2d;
+    border-color: #f44336;
+    color: #ffffff;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.6);
+  }
+  
+  #delete-all-form h3 {
+    color: #f44336;
+  }
+  
+  #delete-all-form p {
+    color: #e0e0e0;
+  }
+  
+  #delete-all-form p strong {
+    color: #f44336;
+  }
+}
+
+/* JavaScript-controlled dark theme classes */
+#delete-all-form.dark-theme {
+  background: #2d2d2d;
+  border-color: #f44336;
+  color: #ffffff;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.6);
+}
+
+#delete-all-form.dark-theme h3 {
+  color: #f44336;
+}
+
+#delete-all-form.dark-theme p {
+  color: #e0e0e0;
+}
+
+#delete-all-form.dark-theme p strong {
+  color: #f44336;
+}
+
 /* Edit form */
 
 #cover {

--- a/js/redirectorpage.js
+++ b/js/redirectorpage.js
@@ -265,6 +265,22 @@ function moveDownBottom(index) {
 	saveChanges();
 }
 
+function deleteAllRedirects() {
+	showForm('#delete-all-form');
+}
+
+function confirmDeleteAll() {
+	REDIRECTS = [];
+	renderRedirects();
+	saveChanges();
+	hideForm('#delete-all-form');
+	showMessage('All redirects have been deleted.', true);
+}
+
+function cancelDeleteAll() {
+	hideForm('#delete-all-form');
+}
+
 //All the setup stuff for the page
 function pageLoad() {
 	template = el('#redirect-row-template');
@@ -315,6 +331,9 @@ function pageLoad() {
 	//Setup event listeners
 	el('#hide-message').addEventListener('click', hideMessage);
 	el('#storage-sync-option input').addEventListener('click', toggleSyncSetting);
+	el('#delete-all-btn').addEventListener('click', deleteAllRedirects);
+	el('#confirm-delete-all').addEventListener('click', confirmDeleteAll);
+	el('#cancel-delete-all').addEventListener('click', cancelDeleteAll);
 	el('.redirect-rows').addEventListener('click', function(ev) {
 		if(ev.target.type == 'checkbox') {
 			ev.target.nextElementSibling.classList.add("checkMarked");

--- a/redirector.html
+++ b/redirector.html
@@ -41,6 +41,18 @@
 			</div>
 		</div>
 
+		<!-- Confirmation form for deleting all redirects -->
+		<div id="delete-all-form">
+			<h3>Delete All Redirects</h3>
+			<div>
+				<p>Are you sure you want to delete ALL redirects? This action cannot be undone.</p>
+				<p><strong>Warning:</strong> This will remove all your redirect rules and reset to default settings.</p>
+			</div>
+			<div class="button-container">
+				<button id="confirm-delete-all" class="btn red large">Yes, delete all redirects</button>
+				<button id="cancel-delete-all" class="btn grey large">No, keep my redirects</button>
+			</div>
+		</div>
 
 		<!-- Form for creating and editing redirects -->
 		<div id="edit-redirect-form">
@@ -144,6 +156,7 @@
 				</span>
 
 				<a class="btn blue large" href="help.html" target="_blank">Help</a>
+				<button id="delete-all-btn" class="btn red large">Delete All</button>
 			</div>
 
 


### PR DESCRIPTION
Introduces a confirmation modal for deleting all redirects, including new styles, HTML markup, and JavaScript logic. Users are now prompted to confirm before all redirect rules are removed, improving safety and user experience.

Resolves https://github.com/einaregilsson/Redirector/issues/388