### PR TITLE
feat: `Copy with Redirect` context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ What are bangs?: <https://duckduckgo.com/bangs>
 - Description: Create new !ghh bang that redirects to <https://githistory.xyz>
 - Advanced:
     - Process matches: URL decode
-    
+
 ### Fast DuckDuckGo.com !bangs
 
 Go directly to frequently used DuckDuckGo bangs to avoid intermediary network requests.
@@ -85,9 +85,9 @@ Go directly to frequently used DuckDuckGo bangs to avoid intermediary network re
 - Redirect to: `https://google.com/search?hl=en&q=$1+$2`
 - Pattern type: Regular Expression
 - Description: DuckDuckGo → Google !bang shortcut (prefix AND suffix)
-- Pattern Description: Avoid extraneous + in URL with two separate patterns  
+- Pattern Description: Avoid extraneous + in URL with two separate patterns
 ###
-  
+
 - Example URL: `https://duckduckgo.com/?q=foo+bar+%21google`
 - Include pattern: `^https://duckduckgo\.com/\?q=(.*?)\+?(?:%21|!)google\b\+?(.*?)(?:&|$)`
 - Redirect to: `https://google.com/search?hl=en&q=$1$2`

--- a/js/popup.js
+++ b/js/popup.js
@@ -21,7 +21,7 @@ function openRedirectorSettings() {
 
 	//switch to open one if we have it to minimize conflicts
 	var url = chrome.extension.getURL('redirector.html');
-	
+
 	//FIREFOXBUG: Firefox chokes on url:url filter if the url is a moz-extension:// url
 	//so we don't use that, do it the more manual way instead.
 	chrome.tabs.query({currentWindow:true}, function(tabs) {
@@ -41,12 +41,13 @@ function openRedirectorSettings() {
 
 
 function pageLoad() {
-	storage.get({logging:false, enableNotifications:false, disabled: false}, function(obj) {
+	storage.get({ logging: false, enableNotifications: false, disableContextMenu: false, disabled: false }, function(obj) {
 		viewModel = obj;
 		applyBinding();
 	})
 
 	el('#enable-notifications').addEventListener('input', () => toggle('enableNotifications'));
+	el('#disable-context-menu').addEventListener('input', () => toggle('disableContextMenu'));
 	el('#enable-logging').addEventListener('input', () => toggle('logging'));
 	el('#toggle-disabled').addEventListener('click', () => toggle('disabled'));
 	el('#open-redirector-settings').addEventListener('click', openRedirectorSettings);

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,9 @@
     "tabs",
     "http://*/*",
     "https://*/*",
-    "notifications"
+    "notifications",
+    "contextMenus",
+    "clipboardWrite"
   ],
   "applications": {
     "gecko": {

--- a/popup.html
+++ b/popup.html
@@ -13,6 +13,7 @@
         <button id="open-redirector-settings">Edit Redirects</button>
 		<label><input id="enable-logging" type="checkbox" data-bind="logging" /> <span>Enable logging</span></label>
 		<label><input id="enable-notifications" type="checkbox" data-bind="enableNotifications" /> <span>Enable notifications</span></label>
+		<label><input id="disable-context-menu" type="checkbox" data-bind="disableContextMenu" /> <span>Disable context menu</span></label>
 		<script src="js/stub.js"></script>
 		<script src="js/util.js"></script>
 		<script src="js/popup.js"></script>


### PR DESCRIPTION
This has no AI slop :), ~~the only issue's that if you check for matches when showing the context menu, it's a bit inconsistent to have it append. I'll see if I can improve that, I don't think I can hold the rendering of the context menu with a promise~~. Append `?w=1` to the diff to get a less crazy looking diff, there was a lot of trailing whitespace that my editor decided to trim.

closes #443
closes #414

___

Challenges:

- [x] Writing to Chromium's clipboard requires moving some logic out of background, or using the different legacy API.
- After taking a look at Chrome's `contextMenus` API for this, it's a lot more basic than Firefox's `menus`, so it's not possible to have match based contexts across browsers (e.g. https://issues.chromium.org/issues/40467152). It'd be cool if `targetUrlPatterns` worked on `link` types. _As a workaround, I added a global toggle_.