### PR TITLE
Add error code-based redirect support

### DIFF
--- a/js/editredirect.js
+++ b/js/editredirect.js
@@ -65,6 +65,7 @@ function editFormChange() {
 
 	activeRedirect.processMatches = el('#process-matches option:checked').value;
 	activeRedirect.patternType = el('[name="patterntype"]:checked').value;
+	activeRedirect.errorCodes = el('input[data-bind="errorCodes"]').value;
 
 	activeRedirect.updateExampleResult();
 

--- a/js/redirect.js
+++ b/js/redirect.js
@@ -44,6 +44,7 @@ Redirect.prototype = {
 	processMatches : 'noProcessing',
 	disabled : false,
 	grouped: false,
+	errorCodes : '', // Comma-separated list of HTTP error codes (e.g., "404,500")
 
 	compile : function() {
 
@@ -67,6 +68,7 @@ Redirect.prototype = {
 			&& this.redirectUrl == redirect.redirectUrl
 			&& this.patternType == redirect.patternType
 			&& this.processMatches == redirect.processMatches
+			&& this.errorCodes == redirect.errorCodes
 			&& this.appliesTo.toString() == redirect.appliesTo.toString();
 	},
 
@@ -84,6 +86,7 @@ Redirect.prototype = {
 			processMatches : this.processMatches,
 			disabled : this.disabled,
 			grouped: this.grouped,
+			errorCodes : this.errorCodes,
 			appliesTo : this.appliesTo.slice(0)
 		};
 	},
@@ -237,6 +240,7 @@ Redirect.prototype = {
 		}
 
 		this.disabled = !!o.disabled;
+		this.errorCodes = o.errorCodes || '';
 		if (o.appliesTo && o.appliesTo.length) {
 			this.appliesTo = o.appliesTo.slice(0);
 		} else {
@@ -300,5 +304,18 @@ Redirect.prototype = {
 		var shouldExclude = this._rxExclude.test(url);
 		this._rxExclude.lastIndex = 0;
 		return shouldExclude;
+	},
+
+	// Check if this redirect should be applied based on HTTP status code
+	shouldApplyOnErrorCode : function(statusCode) {
+		if (!this.errorCodes || this.errorCodes.trim() === '') {
+			return true; // No error codes specified, apply always
+		}
+		
+		var codes = this.errorCodes.split(',').map(function(code) {
+			return code.trim();
+		});
+		
+		return codes.indexOf(statusCode.toString()) !== -1;
 	}
 };

--- a/redirector.html
+++ b/redirector.html
@@ -76,6 +76,10 @@
 					<div class="input-cell"><input type="text" data-bind="patternDesc" placeholder="Describe your pattern" /></div>
 				</div>
 				<div>
+					<label>Error Codes (optional):</label>
+					<div class="input-cell"><input type="text" data-bind="errorCodes" placeholder="e.g., 404,500 (leave empty to redirect always)" /></div>
+				</div>
+				<div>
 					<label>Example result:</label>
 					<div class="input-cell"><span class="error example-result-error" data-show="error" data-bind="error"></span><span class="example-result" data-show="exampleResult" data-bind="exampleResult"></span></div>
 				</div>
@@ -167,6 +171,9 @@
 								</div>
 								<div data-show="excludePattern">
 									<label>excluding:</label><p data-bind="excludePattern"></p>
+								</div>
+								<div data-show="errorCodes">
+									<label>Error codes:</label><p data-bind="errorCodes"></p>
 								</div>
 								<div data-show="patternDesc">
 									<label>Hint:</label><p data-bind="patternDesc"></p>


### PR DESCRIPTION
Implements the ability to specify HTTP error codes for redirects. Redirects can now be configured to trigger only on certain HTTP status codes, with UI and data model changes to support this feature. Updates background logic to handle pending redirects and apply them after verifying response codes.

Resolves #420